### PR TITLE
Enable redis persistence and backups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,33 @@ script:
   - '[ "$key_val" == "somevalue" ]'
   - '[ "$key_count" == "1" ]'
 
+  # Ensure data are saved upon restart
+  - docker restart r0
+  - for i in {30..0}; do redis-cli -h $HOST_PUB_IP -p $PORT_NODE_0 -a root get somekey &> /dev/null && break; sleep 1; done
+  - "key_val=$(redis-cli -h $HOST_PUB_IP -p $PORT_NODE_0 -a root get somekey)"
+  - "key_count=$(redis-cli -h $HOST_PUB_IP -p $PORT_NODE_0 -a root info | grep 'db0' | cut -d',' -f1 | cut -d'=' -f2)"
+  - '[ "$key_val" == "somevalue" ]'
+  - '[ "$key_count" == "1" ]'
+
+  # Perform successive backups
+  - for i in {30..0}; do docker exec -it r0 /usr/local/bin/backup.sh; sleep 1; done
+
+  # Check that only 20 backups are kept
+  - "bkup_count=$(docker exec -it r0 ls -l /snapshots | grep tar.gz | wc -l)"
+  - '[ "$bkup_count" == "20" ]'
+
+  # Perform recovery and restart redis
+  - docker exec -it r0 rm -rf /data/*
+  - docker exec -it r0 sh -c "tar -xvzf /snapshots/\$(ls -1r /snapshots/ | head -n 1) -C /"
+  - docker restart r0
+  - for i in {30..0}; do redis-cli -h $HOST_PUB_IP -p $PORT_NODE_0 -a root get somekey &> /dev/null && break; sleep 1; done
+
+  # Ensure data are recovered
+  - "key_val=$(redis-cli -h $HOST_PUB_IP -p $PORT_NODE_0 -a root get somekey)"
+  - "key_count=$(redis-cli -h $HOST_PUB_IP -p $PORT_NODE_0 -a root info | grep 'db0' | cut -d',' -f1 | cut -d'=' -f2)"
+  - '[ "$key_val" == "somevalue" ]'
+  - '[ "$key_count" == "1" ]'
+
   # Terminate redis
   - docker rm -f r0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,11 @@ script:
   # Start standalone instance
   - docker run -d -p $PORT_NODE_0:6379 -e REDIS_PASS=root --name r0 maestrano/redis:travis
 
-  # Wait for standalone instance to be up
+  # Wait for instance to be up (via Docker healthcheck)
+  - HEALTH_CHECK="starting"
+  - for i in {30..0}; do; HEALTH_CHECK=$(docker inspect --format='{{.State.Health.Status}}' r0 2>/dev/null); [ "$HEALTH_CHECK" == "running" ] && break; sleep 1; done
+
+  # Wait for instance to be up (via manual check)
   - for i in {30..0}; do redis-cli -h $HOST_PUB_IP -p $PORT_NODE_0 -a root get somekey &> /dev/null && break; sleep 1; done
   - if [ "$i" = 0 ]; then echo 'Redis startup process failed.'; exit 1; fi
 
@@ -44,7 +48,11 @@ script:
   #============================================================================
   - docker run -d -p $PORT_NODE_1:6379 -e REDIS_PASS=root -e REDIS_MASTER=$HOST_PUB_IP:$PORT_NODE_1 -e SELF_HOST=$HOST_PUB_IP -e SELF_PORT=$PORT_NODE_1 --name r1 maestrano/redis:travis
 
-  # Wait for standalone instance to be up
+  # Wait for instance to be up (via Docker healthcheck)
+  - HEALTH_CHECK="starting"
+  - for i in {30..0}; do; HEALTH_CHECK=$(docker inspect --format='{{.State.Health.Status}}' r1 2>/dev/null); [ "$HEALTH_CHECK" == "running" ] && break; sleep 1; done
+
+  # Wait for instance to be up (via manual check)
   - for i in {30..0}; do redis-cli -h $HOST_PUB_IP -p $PORT_NODE_1 -a root get somekey &> /dev/null && break; sleep 1; done
   - if [ "$i" = 0 ]; then echo 'Redis startup process failed.'; exit 1; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,7 @@ script:
   - docker run -d -p $PORT_NODE_0:6379 -e REDIS_PASS=root --name r0 maestrano/redis:travis
 
   # Wait for instance to be up (via Docker healthcheck)
-  - HEALTH_CHECK="starting"
-  - for i in {30..0}; do; HEALTH_CHECK=$(docker inspect --format='{{.State.Health.Status}}' r0 2>/dev/null); [ "$HEALTH_CHECK" == "running" ] && break; sleep 1; done
+  - for i in {30..0}; do HEALTH_CHECK=$(docker inspect --format='{{.State.Health.Status}}' r0 2>/dev/null); [ "$HEALTH_CHECK" == "running" ] && break; sleep 1; done
 
   # Wait for instance to be up (via manual check)
   - for i in {30..0}; do redis-cli -h $HOST_PUB_IP -p $PORT_NODE_0 -a root get somekey &> /dev/null && break; sleep 1; done
@@ -49,8 +48,7 @@ script:
   - docker run -d -p $PORT_NODE_1:6379 -e REDIS_PASS=root -e REDIS_MASTER=$HOST_PUB_IP:$PORT_NODE_1 -e SELF_HOST=$HOST_PUB_IP -e SELF_PORT=$PORT_NODE_1 --name r1 maestrano/redis:travis
 
   # Wait for instance to be up (via Docker healthcheck)
-  - HEALTH_CHECK="starting"
-  - for i in {30..0}; do; HEALTH_CHECK=$(docker inspect --format='{{.State.Health.Status}}' r1 2>/dev/null); [ "$HEALTH_CHECK" == "running" ] && break; sleep 1; done
+  - for i in {30..0}; do HEALTH_CHECK=$(docker inspect --format='{{.State.Health.Status}}' r1 2>/dev/null); [ "$HEALTH_CHECK" == "running" ] && break; sleep 1; done
 
   # Wait for instance to be up (via manual check)
   - for i in {30..0}; do redis-cli -h $HOST_PUB_IP -p $PORT_NODE_1 -a root get somekey &> /dev/null && break; sleep 1; done

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -7,6 +7,10 @@ RUN set -x \
 
 ENV REDIS_PASS **None**
 
+# Backup script
+COPY backup.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/backup.sh
+
 # Entrypoint script
 # Entrypoint directive is specified in inherited image
 COPY docker-entrypoint.sh /usr/local/bin/
@@ -14,6 +18,9 @@ COPY docker-entrypoint.sh /usr/local/bin/
 # Healthcheck
 COPY healthcheck.sh /usr/local/bin/
 HEALTHCHECK --timeout=5s CMD bash /usr/local/bin/healthcheck.sh
+
+# Expose redis data folder (/data) and backup folder (/snapshots)
+VOLUME ["/data", "/snapshots"]
 
 # Default start
 CMD [ "redis-server", "/usr/local/etc/redis/redis.conf" ]

--- a/3.2/Dockerfile
+++ b/3.2/Dockerfile
@@ -6,5 +6,14 @@ RUN set -x \
   && chown redis:redis /usr/local/etc/redis/redis.conf
 
 ENV REDIS_PASS **None**
+
+# Entrypoint script
+# Entrypoint directive is specified in inherited image
 COPY docker-entrypoint.sh /usr/local/bin/
+
+# Healthcheck
+COPY healthcheck.sh /usr/local/bin/
+HEALTHCHECK --timeout=5s CMD bash /usr/local/bin/healthcheck.sh
+
+# Default start
 CMD [ "redis-server", "/usr/local/etc/redis/redis.conf" ]

--- a/3.2/backup.sh
+++ b/3.2/backup.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# This script creates a full backup of the redis data store
+# and rollover the backup files
+#
+set -e
+
+# Configuration
+BKUP_DIR=${BKUP_DIR:-"/snapshots"}
+BKUP_RETENTION=${BKUP_RETENTION:-20}
+
+# Ensure backup directory exists
+mkdir -p $BKUP_DIR
+
+# Trigger full snapshot (.rdb)
+redis-cli -a $REDIS_PASS save
+
+# Perform backup (save both .rdb dump and appendonly.aof)
+cd /tmp
+ts=$(date -u +"%Y-%m-%dT%H-%M-%SZ")
+tar -zcf $ts.tar.gz /data
+mv /tmp/$ts.tar.gz $BKUP_DIR/
+
+# Keep limited number of backups
+ls -1 $BKUP_DIR/*.tar.gz | head -n -${BKUP_RETENTION} | xargs rm -f --

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 set -e
 
-# Set Redis pass if defined
+# Set config variables
 conf_file=/usr/local/etc/redis/redis.conf
+
+# Configure AOF persistence by default
+# (persist across restarts)
+if grep -q appendonly $conf_file; then
+  echo "appendonly yes" >> $conf_file
+fi
+
+# Set Redis pass if defined
 if [ "${REDIS_PASS}" != "**None**" ] && ! grep -q 'requirepass' $conf_file; then
   echo "requirepass $REDIS_PASS" >> $conf_file
 fi

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -6,7 +6,7 @@ conf_file=/usr/local/etc/redis/redis.conf
 
 # Configure AOF persistence by default
 # (persist across restarts)
-if grep -q appendonly $conf_file; then
+if grep -q -v appendonly $conf_file; then
   echo "appendonly yes" >> $conf_file
 fi
 

--- a/3.2/healthcheck.sh
+++ b/3.2/healthcheck.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# This script must exit with:
+# 0 on success
+# 1 on error
+
+# Abort if no healthcheck
+[ "$NO_HEALTHCHECK" == "true" ] && exit 0
+
+# Check read access to Redis
+redis-cli -a $REDIS_PASS get somekey || exit 1


### PR DESCRIPTION
- Use redis AOF by default to ensure persistence across restarts.
- Add backup script
- Expose snapshots folder as volume